### PR TITLE
A few different placement rules and behavioral rule

### DIFF
--- a/blocksandstuff-blocks/src/main/kotlin/org/everbuild/blocksandstuff/blocks/behavior/BlockBehaviorRuleRegistrations.kt
+++ b/blocksandstuff-blocks/src/main/kotlin/org/everbuild/blocksandstuff/blocks/behavior/BlockBehaviorRuleRegistrations.kt
@@ -2,19 +2,33 @@ package org.everbuild.blocksandstuff.blocks.behavior
 
 import net.minestom.server.MinecraftServer
 import net.minestom.server.event.player.PlayerBlockPlaceEvent
+import net.minestom.server.instance.block.Block
+import net.minestom.server.inventory.InventoryType
 
 object BlockBehaviorRuleRegistrations {
     @JvmStatic
     fun registerDefault() {
         val handler = MinecraftServer.getGlobalEventHandler()
+        val manager = MinecraftServer.getBlockManager()
         handler.addListener(PlayerBlockPlaceEvent::class.java) {
             val handler = MinecraftServer.getBlockManager().getHandler(it.block.key().asString())
             if (it.block.handler() != handler) it.block = it.block.withHandler(handler)
         }
+
+        manager.registerHandler(Block.CRAFTING_TABLE.key()) { GenericWorkStationRule(Block.CRAFTING_TABLE, InventoryType.CRAFTING, "Crafting") }
+        manager.registerHandler(Block.ANVIL.key()) { GenericWorkStationRule(Block.ANVIL, InventoryType.ANVIL, "Repair & Name") }
+        manager.registerHandler(Block.BREWING_STAND.key()) { GenericWorkStationRule(Block.BREWING_STAND, InventoryType.BREWING_STAND, "Brewing Stand") }
+        manager.registerHandler(Block.LOOM.key()) { GenericWorkStationRule(Block.LOOM, InventoryType.LOOM, "Loom") }
+        manager.registerHandler(Block.GRINDSTONE.key()) { GenericWorkStationRule(Block.GRINDSTONE, InventoryType.GRINDSTONE, "Repair & Disenchant") }
+        manager.registerHandler(Block.SMITHING_TABLE.key()) { GenericWorkStationRule(Block.SMITHING_TABLE, InventoryType.SMITHING, "Upgrade Gear") }
+        manager.registerHandler(Block.CARTOGRAPHY_TABLE.key()) { GenericWorkStationRule(Block.CARTOGRAPHY_TABLE, InventoryType.CARTOGRAPHY, "Cartography Table") }
+        manager.registerHandler(Block.STONECUTTER.key()) { GenericWorkStationRule(Block.STONECUTTER, InventoryType.STONE_CUTTER, "Stonecutter") }
+        manager.registerHandler(Block.ENCHANTING_TABLE.key()) { GenericWorkStationRule(Block.ENCHANTING_TABLE, InventoryType.ENCHANTMENT, "Enchant") }
+
         val copperBlocks = CopperOxidationRule.getOxidizableBlocks()
         for (copperBlock in copperBlocks) {
             val copperOxidationRule = CopperOxidationRule(copperBlock)
-            MinecraftServer.getBlockManager().registerHandler(copperBlock.key()) { copperOxidationRule }
+            manager.registerHandler(copperBlock.key()) { copperOxidationRule }
         }
     }
 }

--- a/blocksandstuff-blocks/src/main/kotlin/org/everbuild/blocksandstuff/blocks/behavior/GenericWorkStationRule.kt
+++ b/blocksandstuff-blocks/src/main/kotlin/org/everbuild/blocksandstuff/blocks/behavior/GenericWorkStationRule.kt
@@ -1,0 +1,22 @@
+package org.everbuild.blocksandstuff.blocks.behavior
+
+import net.kyori.adventure.key.Key
+import net.minestom.server.instance.block.Block
+import net.minestom.server.instance.block.BlockHandler
+import net.minestom.server.inventory.Inventory
+import net.minestom.server.inventory.InventoryType
+
+
+class GenericWorkStationRule(private val block: Block, private val type: InventoryType, private val title: String) : BlockHandler {
+
+    override fun getKey(): Key {
+        return block.key()
+    }
+
+    override fun onInteract(interaction: BlockHandler.Interaction): Boolean {
+        if (interaction.player.isSneaking && !interaction.player.itemInMainHand.isAir) return super.onInteract(interaction)
+        interaction.player.openInventory(Inventory(type, title))
+        return false
+    }
+
+}

--- a/blocksandstuff-blocks/src/main/kotlin/org/everbuild/blocksandstuff/blocks/group/VanillaPlacementRules.kt
+++ b/blocksandstuff-blocks/src/main/kotlin/org/everbuild/blocksandstuff/blocks/group/VanillaPlacementRules.kt
@@ -196,6 +196,13 @@ object VanillaPlacementRules {
         ::FencePlacementRule
     )
 
+    val IRON_BARS = group(
+        all(
+            byBlock(Block.IRON_BARS),
+        ),
+        ::IronBarPlacementRule
+    )
+
     val STAIRS = group(
         all(
             byTag("minecraft:stairs"),

--- a/blocksandstuff-blocks/src/main/kotlin/org/everbuild/blocksandstuff/blocks/group/VanillaPlacementRules.kt
+++ b/blocksandstuff-blocks/src/main/kotlin/org/everbuild/blocksandstuff/blocks/group/VanillaPlacementRules.kt
@@ -196,6 +196,13 @@ object VanillaPlacementRules {
         ::FencePlacementRule
     )
 
+    val STAIRS = group(
+        all(
+            byTag("minecraft:stairs"),
+        ),
+        ::StairsPlacementRule
+    )
+
     val IRON_BARS = group(
         all(
             byBlock(Block.IRON_BARS),
@@ -203,11 +210,11 @@ object VanillaPlacementRules {
         ::IronBarPlacementRule
     )
 
-    val STAIRS = group(
+    val LADDER = group(
         all(
-            byTag("minecraft:stairs"),
+            byBlock(Block.LADDER),
         ),
-        ::StairsPlacementRule
+        ::LadderPlacementRule
     )
 
     private fun group(blockGroup: BlockGroup, valueFunction: Function<Block, BlockPlacementRule>): PlacementGroup {

--- a/blocksandstuff-blocks/src/main/kotlin/org/everbuild/blocksandstuff/blocks/placement/IronBarPlacementRule.kt
+++ b/blocksandstuff-blocks/src/main/kotlin/org/everbuild/blocksandstuff/blocks/placement/IronBarPlacementRule.kt
@@ -1,0 +1,67 @@
+package org.everbuild.blocksandstuff.blocks.placement
+
+import net.kyori.adventure.key.Key
+import net.minestom.server.coordinate.Point
+import net.minestom.server.instance.block.Block
+import net.minestom.server.instance.block.BlockFace
+import net.minestom.server.instance.block.rule.BlockPlacementRule
+import net.minestom.server.registry.RegistryTag
+import org.everbuild.blocksandstuff.blocks.placement.util.States
+import java.util.Map
+import kotlin.collections.plus
+
+class IronBarPlacementRule(block: Block) : BlockPlacementRule(block) {
+    private val tagManager = Block.staticRegistry()
+    private val leaves = tagManager.getTag(Key.key("minecraft:leaves"))!!
+    private val shulkerBoxes = tagManager.getTag(Key.key("minecraft:shulker_boxes"))!!
+    private val cannotConnect = RegistryTag.direct<Block>(
+        shulkerBoxes.toList()
+                + leaves.toList()
+                + listOf(Block.BARRIER, Block.CARVED_PUMPKIN, Block.JACK_O_LANTERN, Block.MELON, Block.PUMPKIN)
+    )
+
+    override fun blockUpdate(updateState: UpdateState): Block {
+        val instance = updateState.instance()
+        val placePos = updateState.blockPosition()
+        val north = placePos.relative(BlockFace.NORTH)
+        val east = placePos.relative(BlockFace.EAST)
+        val south = placePos.relative(BlockFace.SOUTH)
+        val west = placePos.relative(BlockFace.WEST)
+
+        return updateState.currentBlock().withProperties(
+            Map.of<String, String>(
+                States.NORTH, canConnect(instance, north, BlockFace.SOUTH).toString(),
+                States.EAST, canConnect(instance, east, BlockFace.WEST).toString(),
+                States.SOUTH, canConnect(instance, south, BlockFace.NORTH).toString(),
+                States.WEST, canConnect(instance, west, BlockFace.EAST).toString()
+            )
+        )
+    }
+
+    override fun blockPlace(placementState: PlacementState): Block? {
+        val instance = placementState.instance()
+        val placePos = placementState.placePosition()
+        val north = placePos.relative(BlockFace.NORTH)
+        val east = placePos.relative(BlockFace.EAST)
+        val south = placePos.relative(BlockFace.SOUTH)
+        val west = placePos.relative(BlockFace.WEST)
+
+
+        return placementState.block().withProperties(
+            Map.of<String, String>(
+                States.NORTH, canConnect(instance, north, BlockFace.SOUTH).toString(),
+                States.EAST, canConnect(instance, east, BlockFace.WEST).toString(),
+                States.SOUTH, canConnect(instance, south, BlockFace.NORTH).toString(),
+                States.WEST, canConnect(instance, west, BlockFace.EAST).toString()
+            )
+        )
+    }
+
+    private fun canConnect(instance: Block.Getter, pos: Point, blockFace: BlockFace): Boolean {
+        val instanceBlock = instance.getBlock(pos)
+        val isFaceFull = instanceBlock.registry().collisionShape().isFaceFull(blockFace)
+
+        return (!cannotConnect.contains(instanceBlock) && isFaceFull) || instanceBlock.key().equals(this.block.key())
+    }
+
+}

--- a/blocksandstuff-blocks/src/main/kotlin/org/everbuild/blocksandstuff/blocks/placement/LadderPlacementRule.kt
+++ b/blocksandstuff-blocks/src/main/kotlin/org/everbuild/blocksandstuff/blocks/placement/LadderPlacementRule.kt
@@ -1,0 +1,33 @@
+package org.everbuild.blocksandstuff.blocks.placement
+
+import net.minestom.server.instance.block.Block
+import net.minestom.server.instance.block.BlockFace
+import net.minestom.server.instance.block.rule.BlockPlacementRule
+import org.everbuild.blocksandstuff.common.item.DroppedItemFactory
+import org.everbuild.blocksandstuff.common.utils.getNearestHorizontalLookingDirection
+
+class LadderPlacementRule(block: Block) : BlockPlacementRule(block) {
+    override fun blockPlace(placementState: PlacementState): Block? {
+        val blockFace = placementState.blockFace() ?: return null
+
+        val supporting = placementState.placePosition.add(blockFace.oppositeFace.toDirection().vec())
+        if (!placementState.instance.getBlock(supporting).registry().collisionShape().isFaceFull(blockFace)) {
+            return null
+        }
+
+        return block
+            .withProperty("facing", blockFace.name.lowercase())
+    }
+
+    override fun blockUpdate(updateState: UpdateState): Block {
+        val facing = BlockFace.valueOf(updateState.currentBlock.getProperty("facing").uppercase())
+        val supportingBlockPos = updateState.blockPosition.add(facing.oppositeFace.toDirection().vec())
+
+        if (!updateState.instance.getBlock(supportingBlockPos).isSolid) {
+            DroppedItemFactory.maybeDrop(updateState)
+            return Block.AIR
+        }
+
+        return updateState.currentBlock
+    }
+}


### PR DESCRIPTION
I forgot to split up the commits into different branches so that they could be committed separately, but oh well lol

These 3 commits add the following:

- A placement rule for ladders; this includes not being able to place on non-full sides of blocks, i.e it can be placed on the back of stairs, but not the sides or front
- A placement rule for iron bars; this is basically the same as the fence rule however it can only connect to full blocks and itself
- A behavior rule for inventory based work stations; this includes things like the crafting table, loom, anvil, enchanting table (without book support) and a few more.