### PR TITLE
Added GenericWorkStationRule.kt

### DIFF
--- a/blocksandstuff-blocks/src/main/kotlin/org/everbuild/blocksandstuff/blocks/behavior/BlockBehaviorRuleRegistrations.kt
+++ b/blocksandstuff-blocks/src/main/kotlin/org/everbuild/blocksandstuff/blocks/behavior/BlockBehaviorRuleRegistrations.kt
@@ -2,19 +2,34 @@ package org.everbuild.blocksandstuff.blocks.behavior
 
 import net.minestom.server.MinecraftServer
 import net.minestom.server.event.player.PlayerBlockPlaceEvent
+import net.minestom.server.instance.block.Block
+import net.minestom.server.inventory.InventoryType
 
 object BlockBehaviorRuleRegistrations {
     @JvmStatic
     fun registerDefault() {
         val handler = MinecraftServer.getGlobalEventHandler()
+        val manager = MinecraftServer.getBlockManager()
         handler.addListener(PlayerBlockPlaceEvent::class.java) {
             val handler = MinecraftServer.getBlockManager().getHandler(it.block.key().asString())
             if (it.block.handler() != handler) it.block = it.block.withHandler(handler)
         }
+
+        manager.registerHandler(Block.CRAFTING_TABLE.key()) { GenericWorkStationRule(Block.CRAFTING_TABLE, InventoryType.CRAFTING, "Crafting") }
+        manager.registerHandler(Block.ANVIL.key()) { GenericWorkStationRule(Block.ANVIL, InventoryType.ANVIL, "Repair & Name") }
+        manager.registerHandler(Block.BREWING_STAND.key()) { GenericWorkStationRule(Block.BREWING_STAND, InventoryType.BREWING_STAND, "Brewing Stand") }
+        manager.registerHandler(Block.LOOM.key()) { GenericWorkStationRule(Block.LOOM, InventoryType.LOOM, "Loom") }
+        manager.registerHandler(Block.GRINDSTONE.key()) { GenericWorkStationRule(Block.GRINDSTONE, InventoryType.GRINDSTONE, "Repair & Disenchant") }
+        manager.registerHandler(Block.SMITHING_TABLE.key()) { GenericWorkStationRule(Block.SMITHING_TABLE, InventoryType.SMITHING, "Upgrade Gear") }
+        manager.registerHandler(Block.CARTOGRAPHY_TABLE.key()) { GenericWorkStationRule(Block.CARTOGRAPHY_TABLE, InventoryType.CARTOGRAPHY, "Cartography Table") }
+        manager.registerHandler(Block.STONECUTTER.key()) { GenericWorkStationRule(Block.STONECUTTER, InventoryType.STONE_CUTTER, "Stonecutter") }
+        manager.registerHandler(Block.ENCHANTING_TABLE.key()) { GenericWorkStationRule(Block.ENCHANTING_TABLE, InventoryType.ENCHANTMENT, "Enchant") }
+
         val copperBlocks = CopperOxidationRule.getOxidizableBlocks()
         for (copperBlock in copperBlocks) {
             val copperOxidationRule = CopperOxidationRule(copperBlock)
-            MinecraftServer.getBlockManager().registerHandler(copperBlock.key()) { copperOxidationRule }
+            manager.registerHandler(copperBlock.key()) { copperOxidationRule }
         }
+
     }
 }

--- a/blocksandstuff-blocks/src/main/kotlin/org/everbuild/blocksandstuff/blocks/behavior/GenericWorkStationRule.kt
+++ b/blocksandstuff-blocks/src/main/kotlin/org/everbuild/blocksandstuff/blocks/behavior/GenericWorkStationRule.kt
@@ -1,0 +1,22 @@
+package org.everbuild.blocksandstuff.blocks.behavior
+
+import net.kyori.adventure.key.Key
+import net.minestom.server.instance.block.Block
+import net.minestom.server.instance.block.BlockHandler
+import net.minestom.server.inventory.Inventory
+import net.minestom.server.inventory.InventoryType
+
+
+class GenericWorkStationRule(private val block: Block, private val type: InventoryType, private val title: String) : BlockHandler {
+
+    override fun getKey(): Key {
+        return block.key()
+    }
+
+    override fun onInteract(interaction: BlockHandler.Interaction): Boolean {
+        if (interaction.player.isSneaking && !interaction.player.itemInMainHand.isAir) return super.onInteract(interaction)
+        interaction.player.openInventory(Inventory(type, title))
+        return false
+    }
+
+}


### PR DESCRIPTION
This handles most of the workstations, including crafting table, anvil, brewing stand, loom, grindstone, smithing table, cartography table, stonecutter, and enchanting table (no book shelf support)

These GUIs have no functionality to them, but open when clicking the block and have the proper GUI title