### PR TITLE
Added WoodenTrapDoorOpenRule.kt

### DIFF
--- a/blocksandstuff-blocks/src/main/kotlin/org/everbuild/blocksandstuff/blocks/behavior/BlockBehaviorRuleRegistrations.kt
+++ b/blocksandstuff-blocks/src/main/kotlin/org/everbuild/blocksandstuff/blocks/behavior/BlockBehaviorRuleRegistrations.kt
@@ -1,16 +1,30 @@
 package org.everbuild.blocksandstuff.blocks.behavior
 
+import net.kyori.adventure.key.Key
 import net.minestom.server.MinecraftServer
 import net.minestom.server.event.player.PlayerBlockPlaceEvent
+import net.minestom.server.instance.block.Block
 
 object BlockBehaviorRuleRegistrations {
     @JvmStatic
     fun registerDefault() {
         val handler = MinecraftServer.getGlobalEventHandler()
+        val manager = MinecraftServer.getBlockManager()
+        val blockRegistry = Block.staticRegistry();
         handler.addListener(PlayerBlockPlaceEvent::class.java) {
             val handler = MinecraftServer.getBlockManager().getHandler(it.block.key().asString())
             if (it.block.handler() != handler) it.block = it.block.withHandler(handler)
         }
+
+        val woodenTrapDoors = blockRegistry.getTag(Key.key("minecraft:wooden_trapdoors"))
+        if (woodenTrapDoors != null) {
+            for (trapDoor in woodenTrapDoors) {
+                manager.registerHandler(trapDoor.key()) {
+                    WoodenTrapDoorOpenRule(blockRegistry.get(trapDoor))
+                }
+            }
+        }
+
         val copperBlocks = CopperOxidationRule.getOxidizableBlocks()
         for (copperBlock in copperBlocks) {
             val copperOxidationRule = CopperOxidationRule(copperBlock)

--- a/blocksandstuff-blocks/src/main/kotlin/org/everbuild/blocksandstuff/blocks/behavior/WoodenTrapDoorOpenRule.kt
+++ b/blocksandstuff-blocks/src/main/kotlin/org/everbuild/blocksandstuff/blocks/behavior/WoodenTrapDoorOpenRule.kt
@@ -1,0 +1,27 @@
+package org.everbuild.blocksandstuff.blocks.behavior
+
+import net.kyori.adventure.key.Key
+import net.minestom.server.instance.block.Block
+import net.minestom.server.instance.block.BlockHandler
+import net.minestom.server.tag.Tag
+
+
+class WoodenTrapDoorOpenRule(private val block: Block?) : BlockHandler {
+
+    override fun getKey(): Key {
+        return block?.key() ?: key.key()
+    }
+
+    override fun onInteract(interaction: BlockHandler.Interaction): Boolean {
+        if (interaction.player.isSneaking && !interaction.player.itemInMainHand.isAir) return super.onInteract(interaction)
+        var bool = interaction.block.getProperty("open")
+        if (bool.equals("true")) {
+            bool = "false"
+        } else {
+            bool = "true"
+        }
+        interaction.instance.setBlock(interaction.blockPosition, interaction.block.withProperty("open", bool))
+        return false
+    }
+
+}


### PR DESCRIPTION
Allows for wooden trap doors to be opened and closed when interacted with a right click

Iron trap doors need to have a redstone impl 