### PR TITLE
Soul Campfire Fix

### DIFF
--- a/blocksandstuff-blocks/src/main/kotlin/org/everbuild/blocksandstuff/blocks/group/VanillaPlacementRules.kt
+++ b/blocksandstuff-blocks/src/main/kotlin/org/everbuild/blocksandstuff/blocks/group/VanillaPlacementRules.kt
@@ -163,7 +163,10 @@ object VanillaPlacementRules {
     )
 
     val CAMPFIRE = group(
-        byBlock(Block.CAMPFIRE),
+        all(
+            byBlock(Block.CAMPFIRE),
+            byBlock(Block.SOUL_CAMPFIRE),
+        ),
         ::CampfireBlockPlacementRule
     )
 


### PR DESCRIPTION
Added soul_campfire to the CAMPFIRE val in VanillaPlacementRules.kt as it was omitted previously