### PR TITLE
Fix: Block pickup inventory check for same materials

### DIFF
--- a/blocksandstuff-blocks/src/main/kotlin/org/everbuild/blocksandstuff/blocks/BlockPickup.kt
+++ b/blocksandstuff-blocks/src/main/kotlin/org/everbuild/blocksandstuff/blocks/BlockPickup.kt
@@ -20,7 +20,7 @@ object BlockPickup {
 
             for (slot in 0..8) {
                 val item = inventory.getItemStack(slot)
-                if (item.material() === material) {
+                if (item.material() === material) { // TODO: Compare block entity data
                     player.setHeldItemSlot(slot.toByte())
                     return@addListener
                 }
@@ -48,7 +48,7 @@ object BlockPickup {
                     firstAirSlot = slot
                 }
 
-                if (item === newItemStack) {
+                if (item.material() === newItemStack.material()) { // TODO: Compare block entity data
                     inventory.setItemStack(slot, player.itemInMainHand)
                     player.setItemInHand(PlayerHand.MAIN, item)
                     return@addListener


### PR DESCRIPTION
Fix a bug when you have the same material in the inventory and you pickup a block with the same the check inventory ignores it and clone a new item in your hotbar.