### PR TITLE
Water/lava interactions

### DIFF
--- a/blocksandstuff-fluids/src/main/kotlin/org/everbuild/blocksandstuff/fluids/event/FluidBlockReplacementEvent.kt
+++ b/blocksandstuff-fluids/src/main/kotlin/org/everbuild/blocksandstuff/fluids/event/FluidBlockReplacementEvent.kt
@@ -1,0 +1,33 @@
+package org.everbuild.blocksandstuff.fluids.event
+
+import net.minestom.server.coordinate.BlockVec
+import net.minestom.server.event.trait.BlockEvent
+import net.minestom.server.event.trait.CancellableEvent
+import net.minestom.server.event.trait.InstanceEvent
+import net.minestom.server.instance.Instance
+import net.minestom.server.instance.block.Block
+
+/**
+ * Fired when a fluid is replaced by a block
+ * (ex. in the event that water and lava mix)
+ */
+class FluidBlockReplacementEvent(
+    val inst: Instance,
+    var blk: Block,
+    val position: BlockVec
+) : InstanceEvent, BlockEvent, CancellableEvent {
+    private var isCancelled = false
+
+    override fun getBlock(): Block = blk
+    fun setBlock(block: Block) {
+        this.blk = block
+    }
+
+    override fun getBlockPosition(): BlockVec = position
+    override fun getInstance(): Instance = inst
+
+    override fun isCancelled(): Boolean = isCancelled
+    override fun setCancelled(cancel: Boolean) {
+        isCancelled = cancel
+    }
+}

--- a/blocksandstuff-fluids/src/main/kotlin/org/everbuild/blocksandstuff/fluids/impl/EmptyFluid.kt
+++ b/blocksandstuff-fluids/src/main/kotlin/org/everbuild/blocksandstuff/fluids/impl/EmptyFluid.kt
@@ -15,6 +15,12 @@ class EmptyFluid : Fluid(Block.AIR, Material.BUCKET) {
     ): Boolean {
         return true
     }
+    override fun handleInteractionWithFluid(
+        instance: Instance,
+        thisPoint: Point,
+        otherPoint: Point,
+        direction: Direction
+    ) {}
 
     override fun getNextTickDelay(
         instance: Instance,

--- a/blocksandstuff-fluids/src/main/kotlin/org/everbuild/blocksandstuff/fluids/impl/FlowableFluid.kt
+++ b/blocksandstuff-fluids/src/main/kotlin/org/everbuild/blocksandstuff/fluids/impl/FlowableFluid.kt
@@ -51,6 +51,8 @@ abstract class FlowableFluid(defaultBlock: Block, bucket: Material) : Fluid(defa
             }
         } else if (isSource(block) || !canFlowDown(instance, updatedDownFluid, point, block, down, downBlock)) {
             flowSides(instance, point, block)
+        } else {
+            fluid.handleInteractionWithFluid(instance, point, down, Direction.DOWN)
         }
     }
 
@@ -74,8 +76,23 @@ abstract class FlowableFluid(defaultBlock: Block, bucket: Material) : Fluid(defa
                 direction.normalZ().toDouble()
             )
             val currentBlock = instance.getBlock(offset)
-            if (!canFlow(instance, point, block, direction, offset, currentBlock, newBlock)) continue
+            if (!canFlow(instance, point, block, direction, offset, currentBlock, newBlock))
+                continue
             flow(instance, offset, currentBlock, direction, newBlock)
+
+            for (interactionDirection in Direction.HORIZONTAL) {
+                if (interactionDirection == direction.opposite())
+                    continue
+
+                val interactionOffset = offset.add(interactionDirection.vec())
+                val interactionBlock = instance.getBlock(interactionOffset)
+
+                if (MinestomFluids.getFluidOnBlock(interactionBlock) != MinestomFluids.EMPTY) {
+                    val otherFluid = MinestomFluids.getFluidInstanceOnBlock(interactionBlock)
+                    handleInteractionWithFluid(instance, offset, interactionOffset, direction)
+                    otherFluid.handleInteractionWithFluid(instance, interactionOffset, offset, direction)
+                }
+            }
         }
     }
 

--- a/blocksandstuff-fluids/src/main/kotlin/org/everbuild/blocksandstuff/fluids/impl/Fluid.kt
+++ b/blocksandstuff-fluids/src/main/kotlin/org/everbuild/blocksandstuff/fluids/impl/Fluid.kt
@@ -15,6 +15,11 @@ abstract class Fluid(val defaultBlock: Block, bucket: Material) {
         other: Fluid?, direction: Direction?
     ): Boolean
 
+    abstract fun handleInteractionWithFluid(
+        instance: Instance, thisPoint: Point,
+        otherPoint: Point, direction: Direction
+    )
+
     abstract fun getNextTickDelay(instance: Instance, point: Point, block: Block): Int
 
     open fun onTick(instance: Instance, point: Point, block: Block) {}

--- a/blocksandstuff-fluids/src/main/kotlin/org/everbuild/blocksandstuff/fluids/impl/LavaFluid.kt
+++ b/blocksandstuff-fluids/src/main/kotlin/org/everbuild/blocksandstuff/fluids/impl/LavaFluid.kt
@@ -8,6 +8,7 @@ import net.minestom.server.instance.block.Block
 import net.minestom.server.item.Material
 import net.minestom.server.utils.Direction
 import net.minestom.server.world.DimensionType
+import org.everbuild.blocksandstuff.fluids.MinestomFluids
 import org.everbuild.blocksandstuff.fluids.relativeTicks
 
 open class LavaFluid(defaultBlock: Block, bucket: Material) : FlowableFluid(defaultBlock, bucket) {
@@ -49,5 +50,22 @@ open class LavaFluid(defaultBlock: Block, bucket: Material) : FlowableFluid(defa
     ): Boolean {
 
         return direction == Direction.DOWN && this === other
+    }
+
+    override fun handleInteractionWithFluid(
+        instance: Instance,
+        thisPoint: Point,
+        otherPoint: Point,
+        direction: Direction
+    ) {
+        val thisBlock = instance.getBlock(thisPoint)
+        val otherBlock = instance.getBlock(otherPoint)
+        val otherFluid = MinestomFluids.getFluidInstanceOnBlock(otherBlock)
+
+        if (otherFluid is WaterFluid) {
+            if (direction == Direction.DOWN)
+                flow(instance, otherPoint, thisBlock, direction, Block.STONE)
+            else flow(instance, thisPoint, thisBlock, direction, Block.COBBLESTONE)
+        }
     }
 }

--- a/blocksandstuff-fluids/src/main/kotlin/org/everbuild/blocksandstuff/fluids/impl/WaterFluid.kt
+++ b/blocksandstuff-fluids/src/main/kotlin/org/everbuild/blocksandstuff/fluids/impl/WaterFluid.kt
@@ -5,6 +5,7 @@ import net.minestom.server.instance.Instance
 import net.minestom.server.instance.block.Block
 import net.minestom.server.item.Material
 import net.minestom.server.utils.Direction
+import org.everbuild.blocksandstuff.fluids.MinestomFluids
 import org.everbuild.blocksandstuff.fluids.relativeTicks
 
 open class WaterFluid(defaultBlock: Block, bucket: Material) : FlowableFluid(defaultBlock, bucket) {
@@ -34,5 +35,21 @@ open class WaterFluid(defaultBlock: Block, bucket: Material) : FlowableFluid(def
 
     override fun isInTile(block: Block): Boolean {
         return super.isInTile(block) || block.getProperty("waterlogged") == "true"
+    }
+
+    override fun handleInteractionWithFluid(
+        instance: Instance,
+        thisPoint: Point,
+        otherPoint: Point,
+        direction: Direction
+    ) {
+        val thisBlock = instance.getBlock(thisPoint)
+        val otherBlock = instance.getBlock(otherPoint)
+        val otherFluid = MinestomFluids.getFluidInstanceOnBlock(otherBlock)
+
+        if (otherFluid is LavaFluid) {
+            val block = if (isSource(otherBlock)) Block.OBSIDIAN else Block.COBBLESTONE
+            flow(instance, otherPoint, thisBlock, direction, block)
+        }
     }
 }

--- a/blocksandstuff-fluids/src/main/kotlin/org/everbuild/blocksandstuff/fluids/impl/WaterFluid.kt
+++ b/blocksandstuff-fluids/src/main/kotlin/org/everbuild/blocksandstuff/fluids/impl/WaterFluid.kt
@@ -1,11 +1,14 @@
 package org.everbuild.blocksandstuff.fluids.impl
 
+import net.minestom.server.coordinate.BlockVec
 import net.minestom.server.coordinate.Point
+import net.minestom.server.event.EventDispatcher
 import net.minestom.server.instance.Instance
 import net.minestom.server.instance.block.Block
 import net.minestom.server.item.Material
 import net.minestom.server.utils.Direction
 import org.everbuild.blocksandstuff.fluids.MinestomFluids
+import org.everbuild.blocksandstuff.fluids.event.FluidBlockReplacementEvent
 import org.everbuild.blocksandstuff.fluids.relativeTicks
 
 open class WaterFluid(defaultBlock: Block, bucket: Material) : FlowableFluid(defaultBlock, bucket) {
@@ -48,8 +51,18 @@ open class WaterFluid(defaultBlock: Block, bucket: Material) : FlowableFluid(def
         val otherFluid = MinestomFluids.getFluidInstanceOnBlock(otherBlock)
 
         if (otherFluid is LavaFluid) {
-            val block = if (isSource(otherBlock)) Block.OBSIDIAN else Block.COBBLESTONE
-            flow(instance, otherPoint, thisBlock, direction, block)
+            val event = FluidBlockReplacementEvent(
+                instance,
+                if (isSource(otherBlock)) Block.OBSIDIAN else Block.COBBLESTONE,
+                BlockVec(otherPoint)
+            )
+
+            EventDispatcher.call(event)
+
+            if (!event.isCancelled) {
+                val block = event.blk
+                flow(instance, otherPoint, thisBlock, direction, block)
+            }
         }
     }
 }


### PR DESCRIPTION
Implements interactions between water and lava:
- Lava flowing down onto water turns the water into stone.
- Water flowing down onto lava turns the lava into cobblestone.
- Water flowing into a lava source block turns the lava to obsidian.
- Lava/water flowing into each other sideways turns the flowing-into block into cobblestone.

In my testing, lava casting does not work. However, this seems to be due to a lack of parity with vanilla in terms of how fast water and lava drain. The lava would drain before the water could reach the lava, causing the lava casting to be broken.

I didn't tackle that problem in this PR, it may be a good responsibility for my [extra fluid parity PR](https://github.com/everbuild-org/blocks-and-stuff/pull/30), or just a separate PR.