### PR TITLE
feat: set player's item when placing/picking up water/lava

### DIFF
--- a/blocksandstuff-fluids/src/main/kotlin/org/everbuild/blocksandstuff/fluids/listener/FluidPlacementEvent.kt
+++ b/blocksandstuff-fluids/src/main/kotlin/org/everbuild/blocksandstuff/fluids/listener/FluidPlacementEvent.kt
@@ -3,6 +3,7 @@ package org.everbuild.blocksandstuff.fluids.listener
 import net.kyori.adventure.key.Key
 import net.minestom.server.MinecraftServer
 import net.minestom.server.coordinate.Pos
+import net.minestom.server.entity.EquipmentSlot
 import net.minestom.server.entity.PlayerHand
 import net.minestom.server.event.player.PlayerBlockInteractEvent
 import net.minestom.server.instance.block.Block
@@ -51,6 +52,11 @@ fun setupFluidPlacementEvent() {
                         }
                     }
                     event.player.refreshPosition(placePosition)
+                    event.player.inventory.setEquipment(
+                        EquipmentSlot.MAIN_HAND,
+                        event.player.heldSlot,
+                        ItemStack.of(Material.BUCKET)
+                    )
                 }
                 if (itemInMainHand == ItemStack.of(Material.WATER_BUCKET)) {
                     val blockFace = event.blockFace
@@ -91,6 +97,11 @@ fun setupFluidPlacementEvent() {
                         }
                     }
                     event.player.refreshPosition(placePosition, false, true)
+                    event.player.inventory.setEquipment(
+                        EquipmentSlot.MAIN_HAND,
+                        event.player.heldSlot,
+                        ItemStack.of(Material.BUCKET)
+                    )
                 }
             }
         }

--- a/blocksandstuff-fluids/src/main/kotlin/org/everbuild/blocksandstuff/fluids/pickup/FluidPickupListener.kt
+++ b/blocksandstuff-fluids/src/main/kotlin/org/everbuild/blocksandstuff/fluids/pickup/FluidPickupListener.kt
@@ -2,6 +2,7 @@ package org.everbuild.blocksandstuff.fluids.pickup
 
 import net.minestom.server.MinecraftServer
 import net.minestom.server.coordinate.BlockVec
+import net.minestom.server.entity.EquipmentSlot
 import net.minestom.server.entity.attribute.Attribute
 import net.minestom.server.event.EventNode
 import net.minestom.server.event.player.PlayerUseItemEvent
@@ -10,7 +11,10 @@ import net.minestom.server.instance.block.BlockHandler.PlayerPlacement
 import net.minestom.server.item.ItemStack
 import net.minestom.server.item.Material
 import org.everbuild.blocksandstuff.common.utils.eyePosition
+import org.everbuild.blocksandstuff.fluids.MinestomFluids
 import org.everbuild.blocksandstuff.fluids.findBlockFace
+import org.everbuild.blocksandstuff.fluids.impl.LavaFluid
+import org.everbuild.blocksandstuff.fluids.impl.WaterFluid
 import org.everbuild.blocksandstuff.fluids.raycastForFluid
 
 fun getFluidPickupEventNode() = EventNode.all("fluid-pickup")
@@ -49,6 +53,19 @@ fun getFluidPickupEventNode() = EventNode.all("fluid-pickup")
                     liquidBlock.y().toFloat(),
                     liquidBlock.z().toFloat(),
                 )
+            )
+        }
+
+        val fluid = MinestomFluids.getFluidInstanceOnBlock(pickupEvent.sourceBlock)
+
+        if (fluid is WaterFluid || fluid is LavaFluid) {
+            val material = if (fluid is WaterFluid) Material.WATER_BUCKET
+                else Material.LAVA_BUCKET
+
+            event.player.inventory.setEquipment(
+                EquipmentSlot.MAIN_HAND,
+                event.player.heldSlot,
+                ItemStack.of(material)
             )
         }
     }


### PR DESCRIPTION
Sets the player's tool to an empty bucket when they place a fluid, and sets the player's tool to a water/lava bucket when they pick up each respective fluid.

I'm not sure if I should keep basing my PRs against the main branch, please let me know if I should be using the dev branch instead hahaha.