### PR TITLE
fix: correct furnace facing direction to face towards player

### DIFF
--- a/blocksandstuff-blocks/src/main/kotlin/org/everbuild/blocksandstuff/blocks/placement/VerticallyRotatedPlacementRule.kt
+++ b/blocksandstuff-blocks/src/main/kotlin/org/everbuild/blocksandstuff/blocks/placement/VerticallyRotatedPlacementRule.kt
@@ -6,10 +6,14 @@ import org.everbuild.blocksandstuff.common.utils.getHorizontalPlacementDirection
 
 class VerticallyRotatedPlacementRule(block: Block) : BlockPlacementRule(block) {
     override fun blockPlace(placementState: PlacementState): Block {
+        val playerDirection = placementState.getHorizontalPlacementDirection()
+            ?: return placementState.block
+        val blockFacing = playerDirection.opposite()
+
         return placementState.block
             .withProperty(
                 "facing",
-                (placementState.getHorizontalPlacementDirection() ?: return placementState.block).name.lowercase()
+                blockFacing.name.lowercase()
             )
     }
 }


### PR DESCRIPTION
The current `VerticallyRotatedPlacementRule` makes directional blocks (furnaces, dispensers, droppers, smokers, etc.) face the same direction as the player when placed. For example, if a player faces west while placing a furnace, the furnace 
also faces west.

However, in vanilla Minecraft, we expect these blocks to face *towards* the player when placed. To use the same example I mentioned before, if a player faces west while placing a furnace, we expect the furnace to face east instead (towards the player).

To implement a fix for this, I simply added an `opposite()` call on the player's placement direction before applying it to the blocks `facing` property! From some basic testing in a creative server instance, this seems to be a sufficient fix.